### PR TITLE
feat: Update file discovery patterns to support both .mdx and .md extensions and remove import.meta.glob to avoid build of mdx files

### DIFF
--- a/.kiro/specs/blog-md-mdx-support/design.md
+++ b/.kiro/specs/blog-md-mdx-support/design.md
@@ -1,0 +1,206 @@
+# Design Document
+
+## Overview
+
+This design extends the existing blog system to support both `.mdx` and `.md` file formats for blog articles. The current system is hardcoded to only process `.mdx` files through several key components: file discovery, content loading, and static asset generation. The solution involves updating these components to handle both file extensions while maintaining backward compatibility and prioritizing `.mdx` files when both formats exist for the same article.
+
+## Architecture
+
+The blog system consists of several key components that need modification:
+
+1. **File Discovery System** (`discoverArticles()` function)
+2. **Content Loading System** (`loadArticleContent()` function) 
+3. **Article Processing Pipeline** (`processArticle()` function)
+4. **Static Asset Generation** (build script)
+5. **Import Pattern Definitions** (`import.meta.glob` patterns)
+
+The architecture will remain the same, but each component will be enhanced to handle both file extensions with a priority system favoring `.mdx` over `.md`.
+
+## Components and Interfaces
+
+### 1. File Discovery Enhancement
+
+**Current Implementation:**
+- Uses `import.meta.glob("/contents/blog/**/index.mdx")` for Vite environment
+- Scans for `index.mdx` files in Node.js environment
+
+**New Implementation:**
+- Extend `import.meta.glob` to include both patterns: `index.mdx` and `index.md`
+- Update Node.js file system scanning to check for both extensions
+- Implement priority logic: if both `index.mdx` and `index.md` exist, prefer `.mdx`
+
+```typescript
+// New import pattern
+const mdxModules = typeof import.meta.glob !== "undefined"
+  ? {
+      ...import.meta.glob("/contents/blog/**/index.mdx", { query: "?raw", import: "default" }),
+      ...import.meta.glob("/contents/blog/**/index.md", { query: "?raw", import: "default" })
+    }
+  : {};
+```
+
+### 2. Content Loading Enhancement
+
+**Current Implementation:**
+- Hardcoded to look for `.mdx` files
+- Uses specific file paths like `/contents/blog/${slug}/index.mdx`
+
+**New Implementation:**
+- Create a file resolution function that checks for both extensions
+- Implement priority logic in content loading
+- Update static content fetching to handle both formats
+
+```typescript
+// New file resolution logic
+function resolveArticleFile(slug: string): string | null {
+  const mdxPath = `/contents/blog/${slug}/index.mdx`;
+  const mdPath = `/contents/blog/${slug}/index.md`;
+  
+  // Check if MDX exists first (priority)
+  if (mdxModules[mdxPath]) return mdxPath;
+  if (mdxModules[mdPath]) return mdPath;
+  
+  return null;
+}
+```
+
+### 3. Processing Pipeline Enhancement
+
+**Current Implementation:**
+- Single processing path for `.mdx` files
+- Frontmatter validation and content extraction
+
+**New Implementation:**
+- Unified processing for both file types
+- Same frontmatter validation rules apply to both formats
+- Content extraction works identically for both formats (using gray-matter)
+
+### 4. Static Asset Generation Enhancement
+
+**Current Implementation:**
+- Generates `.mdx` files in `public/blog-content/`
+- Build script processes only `.mdx` files
+
+**New Implementation:**
+- Generate unified output format regardless of source extension
+- Maintain `.mdx` extension in output for consistency
+- Update build script to process both file types
+
+## Data Models
+
+No changes to existing data models are required. The `ArticleMetadata` interface and related types remain unchanged since both `.md` and `.mdx` files will use the same frontmatter structure and validation rules.
+
+```typescript
+// Existing interface remains unchanged
+interface ArticleMetadata {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: Date;
+  updatedAt: Date;
+  tags: string[];
+  emoji: string;
+  readingTime: number;
+}
+```
+
+## Error Handling
+
+### File Resolution Errors
+- When neither `.md` nor `.mdx` exists for a slug, return null/404 as before
+- Log warnings when both formats exist (indicating potential confusion)
+- Graceful fallback from `.mdx` to `.md` if `.mdx` fails to load
+
+### Processing Errors
+- Same validation rules apply to both formats
+- Error messages should indicate the actual file extension being processed
+- Build process should continue if one format fails but the other succeeds
+
+### Runtime Errors
+- Static content fetching should handle both formats transparently
+- Cache generation should include articles from both formats
+- Search indexing should work identically for both formats
+
+## Testing Strategy
+
+### Unit Tests
+1. **File Discovery Tests**
+   - Test discovery of `.mdx` files only
+   - Test discovery of `.md` files only  
+   - Test discovery of mixed formats
+   - Test priority logic when both formats exist
+
+2. **Content Loading Tests**
+   - Test loading `.mdx` content
+   - Test loading `.md` content
+   - Test priority resolution
+   - Test error handling for missing files
+
+3. **Processing Pipeline Tests**
+   - Test frontmatter validation for both formats
+   - Test content extraction for both formats
+   - Test metadata generation consistency
+
+### Integration Tests
+1. **Build Process Tests**
+   - Test complete build with `.mdx` files only
+   - Test complete build with `.md` files only
+   - Test complete build with mixed formats
+   - Test static asset generation for both formats
+
+2. **Runtime Tests**
+   - Test article loading in development mode
+   - Test article loading in production mode
+   - Test search functionality with mixed formats
+   - Test navigation between articles of different formats
+
+### Migration Tests
+1. **Format Conversion Tests**
+   - Test converting existing `.mdx` to `.md`
+   - Test that metadata remains consistent after conversion
+   - Test that images and assets continue to work
+   - Test that build process succeeds after conversion
+
+## Implementation Phases
+
+### Phase 1: Core File Discovery
+- Update `import.meta.glob` patterns to include both extensions
+- Modify `discoverArticles()` function for dual format support
+- Implement file resolution priority logic
+
+### Phase 2: Content Loading Enhancement  
+- Update `loadArticleContent()` to handle both formats
+- Modify `processArticle()` to work with resolved file paths
+- Update error handling and logging
+
+### Phase 3: Build Process Updates
+- Modify build script to process both file types
+- Update static content generation
+- Ensure cache generation includes both formats
+
+### Phase 4: Testing and Validation
+- Add comprehensive test coverage
+- Test migration scenarios
+- Validate performance impact
+
+## Performance Considerations
+
+- **File Discovery**: Minimal impact as we're adding one additional glob pattern
+- **Content Loading**: No performance impact as resolution happens once per article
+- **Build Time**: Slight increase due to additional file system checks, but negligible
+- **Runtime**: No impact as static content is pre-generated
+- **Memory Usage**: Minimal increase due to additional module mappings
+
+## Security Considerations
+
+- Both `.md` and `.mdx` files use the same content processing pipeline
+- Same sanitization rules apply to both formats
+- No additional security risks introduced
+- Frontmatter validation remains consistent across formats
+
+## Backward Compatibility
+
+- Existing `.mdx` files continue to work without changes
+- No breaking changes to APIs or interfaces
+- Build process remains compatible with existing workflows
+- Migration from `.mdx` to `.md` is non-breaking (rename operation)

--- a/.kiro/specs/blog-md-mdx-support/requirements.md
+++ b/.kiro/specs/blog-md-mdx-support/requirements.md
@@ -1,0 +1,62 @@
+# Requirements Document
+
+## Introduction
+
+This feature extends the existing blog system to support both `.mdx` and `.md` file formats for blog articles, instead of only supporting `.mdx` files. This change is needed to avoid build errors that can occur with MDX files and provide more flexibility for content creation.
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As a content creator, I want to write blog articles in either `.mdx` or `.md` format, so that I can choose the most appropriate format for my content and avoid potential build errors.
+
+#### Acceptance Criteria
+
+1. WHEN a blog article is created with `.md` extension THEN the system SHALL process it the same way as `.mdx` files
+2. WHEN a blog article is created with `.mdx` extension THEN the system SHALL continue to process it as before
+3. WHEN both `.md` and `.mdx` files exist for the same article THEN the system SHALL prioritize `.mdx` over `.md`
+4. WHEN the build process runs THEN it SHALL discover both `.md` and `.mdx` files in the blog content directory
+
+### Requirement 2
+
+**User Story:** As a developer, I want the file discovery system to automatically detect both `.md` and `.mdx` files, so that the build process works seamlessly regardless of file extension.
+
+#### Acceptance Criteria
+
+1. WHEN the `discoverArticles()` function runs THEN it SHALL scan for both `index.md` and `index.mdx` files
+2. WHEN the `import.meta.glob` pattern is used THEN it SHALL include both `.md` and `.mdx` extensions
+3. WHEN processing articles during build THEN the system SHALL handle both file types with the same frontmatter validation
+4. WHEN generating the article cache THEN both `.md` and `.mdx` articles SHALL be included
+
+### Requirement 3
+
+**User Story:** As a content creator, I want the same frontmatter format and validation to work for both `.md` and `.mdx` files, so that I can migrate between formats without changing my content structure.
+
+#### Acceptance Criteria
+
+1. WHEN a `.md` file is processed THEN it SHALL use the same frontmatter validation as `.mdx` files
+2. WHEN a `.md` file is processed THEN it SHALL support the same frontmatter fields (title, slug, publishedAt, updatedAt, tags, description, emoji)
+3. WHEN content is loaded at runtime THEN both `.md` and `.mdx` files SHALL be accessible through the same API
+4. WHEN the search index is built THEN both `.md` and `.mdx` content SHALL be included
+
+### Requirement 4
+
+**User Story:** As a developer, I want the static content generation to work for both file types, so that the runtime performance remains optimal.
+
+#### Acceptance Criteria
+
+1. WHEN the build script runs THEN it SHALL generate static content files for both `.md` and `.mdx` articles
+2. WHEN static content is generated THEN both file types SHALL be converted to the same output format
+3. WHEN the public blog-content directory is created THEN it SHALL contain processed content from both `.md` and `.mdx` files
+4. WHEN content is served at runtime THEN the file extension SHALL not affect the user experience
+
+### Requirement 5
+
+**User Story:** As a content creator, I want to be able to convert existing `.mdx` files to `.md` files, so that I can avoid build errors when needed.
+
+#### Acceptance Criteria
+
+1. WHEN an existing `.mdx` file is renamed to `.md` THEN the system SHALL continue to process it correctly
+2. WHEN the frontmatter remains unchanged during conversion THEN the article SHALL maintain all its metadata
+3. WHEN images and assets are referenced in the content THEN they SHALL continue to work after format conversion
+4. WHEN the build process runs after conversion THEN it SHALL not produce any errors

--- a/.kiro/specs/blog-md-mdx-support/tasks.md
+++ b/.kiro/specs/blog-md-mdx-support/tasks.md
@@ -1,0 +1,62 @@
+# Implementation Plan
+
+- [ ] 1. Update file discovery patterns to support both .mdx and .md extensions
+  - Modify the `import.meta.glob` pattern in `app/lib/blog/mdx-processor.ts` to include both `/contents/blog/**/index.mdx` and `/contents/blog/**/index.md`
+  - Update the `mdxModules` object to merge both glob patterns
+  - _Requirements: 2.1, 2.2_
+
+- [ ] 2. Implement file resolution priority logic
+  - Create a `resolveArticleFile()` helper function that checks for both extensions with .mdx priority
+  - Update the `discoverArticles()` function to use the new resolution logic
+  - Ensure Node.js environment file system scanning checks for both extensions
+  - _Requirements: 1.3, 2.1_
+
+- [ ] 3. Update content loading to handle both file formats
+  - Modify `loadArticleContent()` function to use the new file resolution logic
+  - Update both Vite environment (import.meta.glob) and Node.js environment (file system) code paths
+  - Ensure static content fetching works for both formats
+  - _Requirements: 2.3, 4.2_
+
+- [ ] 4. Update article processing pipeline for dual format support
+  - Modify `processArticle()` function to work with resolved file paths of either extension
+  - Ensure frontmatter validation works identically for both .md and .mdx files
+  - Update error messages to indicate the actual file extension being processed
+  - _Requirements: 3.1, 3.2_
+
+- [ ] 5. Update build script to process both file types
+  - Modify `scripts/build-blog.ts` to handle articles from both .md and .mdx files
+  - Ensure static content generation in `public/blog-content/` works for both formats
+  - Update MDX file generation to maintain .mdx extension in output regardless of source format
+  - _Requirements: 4.1, 4.3_
+
+- [ ] 6. Update image processing to handle both file formats
+  - Modify `app/lib/blog/image-processor.ts` to exclude both `index.mdx` and `index.md` from image processing
+  - Ensure image discovery works correctly regardless of article file extension
+  - _Requirements: 5.3_
+
+- [ ] 7. Add comprehensive unit tests for dual format support
+  - Create tests for file discovery with .mdx files only, .md files only, and mixed formats
+  - Add tests for priority resolution when both formats exist for the same article
+  - Test content loading for both file formats
+  - Test frontmatter validation consistency across formats
+  - _Requirements: 3.1, 3.2, 3.3_
+
+- [ ] 8. Add integration tests for build and runtime scenarios
+  - Test complete build process with .mdx files only, .md files only, and mixed formats
+  - Test static asset generation for both formats
+  - Test article loading in both development and production modes
+  - Test search functionality with mixed formats
+  - _Requirements: 4.4, 2.4_
+
+- [ ] 9. Add migration tests for format conversion
+  - Test converting existing .mdx files to .md format
+  - Verify metadata consistency after format conversion
+  - Test that images and assets continue to work after conversion
+  - Verify build process succeeds after format conversion
+  - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+- [ ] 10. Update documentation and add logging improvements
+  - Add informative logging when both formats exist for the same article
+  - Update error messages to be more descriptive about file format issues
+  - Add console warnings for potential format conflicts
+  - _Requirements: 1.3, 2.1_

--- a/.kiro/specs/blog-md-mdx-support/tasks.md
+++ b/.kiro/specs/blog-md-mdx-support/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. Update file discovery patterns to support both .mdx and .md extensions
+- [x] 1. Update file discovery patterns to support both .mdx and .md extensions
   - Modify the `import.meta.glob` pattern in `app/lib/blog/mdx-processor.ts` to include both `/contents/blog/**/index.mdx` and `/contents/blog/**/index.md`
   - Update the `mdxModules` object to merge both glob patterns
   - _Requirements: 2.1, 2.2_

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "tw-animate-css": "^1.3.5",
         "typescript": "^5.8.3",
         "vite": "^6.3.3",
+        "vite-plugin-string": "^1.2.3",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4",
         "wrangler": "^4.13.2"
@@ -9984,6 +9985,19 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/vite-plugin-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-string/-/vite-plugin-string-1.2.3.tgz",
+      "integrity": "sha512-zw2jL0c4B6CAvxO8PshX04494jTcqJjNH2kW1AugBH+fImRY0evdNtVgmeS1i1VFdua/OFhL7fMqIPh0uF21/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": ">=4.1.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2"
+      }
     },
     "node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "tw-animate-css": "^1.3.5",
     "typescript": "^5.8.3",
     "vite": "^6.3.3",
+    "vite-plugin-string": "^1.2.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4",
     "wrangler": "^4.13.2"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,6 @@ export default defineConfig(({ mode }) => ({
   ],
   test: {
     globals: true,
-    setupFiles: ['./test/setup.ts'],    
+    setupFiles: ['./test/setup.ts'],
   },
 }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated design, requirements, and implementation plan documents to outline support for both `.mdx` and `.md` blog article formats.

* **Chores**
  * Updated development dependencies by adding `vite-plugin-string`.
  * Removed trailing whitespace in configuration files.

* **Refactor**
  * Simplified blog article discovery and content loading by removing static import mechanisms, now relying solely on dynamic file system operations for both `.mdx` and `.md` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->